### PR TITLE
Corrections anonymity and monotonicity; requirement no empty ballots + new iterate and results file; 

### DIFF
--- a/approval_results.txt
+++ b/approval_results.txt
@@ -1,21 +1,31 @@
 3,1,1:
-I,NU,PU =K: False
 I,A,NE =K: False
+I,strong-A,NE =K: False
+I,CNU,CPU =K: False
 
 3,2,1:
-I,NU,PU =K: False
 I,A,NE =K: False
+I,strong-A,NE =K: False
+I,CNU,CPU =K: False
 
 3,1,2:
-I,NU,PU =K: False
 I,A,NE =K: False
+I,strong-A,NE =K: False
+I,CNU,CPU =K: False
 
 3,2,2:
-I,NU,PU =K: False
-I,A,NE =K: False
+I,A,NE =K: True
+I,strong-A,NE =K: False
+I,CNU,CPU =K: False
 
 4,1,1:
-I,NU,PU =K: False
 I,A,NE =K: False
+I,strong-A,NE =K: False
+I,CNU,CPU =K: False
 
 4,2,1:
+I,A,NE =K: True
+I,strong-A,NE =K: False
+I,CNU,CPU =K: False
+
+4,3,1:

--- a/approval_results_no_empty_ballots.txt
+++ b/approval_results_no_empty_ballots.txt
@@ -1,0 +1,25 @@
+3,1,1:
+I, A, NE: False
+I, strong-A, NE: False
+I, CNU, CPU: False
+
+3,2,1:
+I, A, NE: False
+I, strong-A, NE: False
+I, CNU, CPU: False
+
+3,1,2:
+I, A, NE: False
+I, strong-A, NE: False
+I, CNU, CPU: False
+
+3,2,2:
+I, A, NE: True
+I, strong-A, NE: False
+I, CNU, CPU: False
+
+4,1,1:
+I, A, NE: False
+I, strong-A, NE: False
+I, CNU, CPU: False
+


### PR DESCRIPTION
1. I have added an anonymity axiom which considers only whether the same ballots have been submitted. The requirement that profiles with identical approval scores for all agents should have the same output is now called ApprovalScoreAnonymity.
2. I fixed monotonicity so we only consider changes of profile in which some voter adds i to their ballot or replaces *exactly one* (before it was any number) of the approvals with i.
3. I have added a new iterate file, iterateAPGNoEmptyBallots.py in which we do not allow voters to submit empty ballots (so as to reduce to the Holzman framework). For the SAT-solving I have hardcoded the Holzman impossibilities so that we only need to generate certain cnfs, e.g., impartiality, once per iteration (not sure if this makes a very big difference, but maybe). I have also added an according results file, approval_results_no_empty_ballots.txt.